### PR TITLE
Call MPI_Init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 .idea/
 CMakeLists.txt.user
+.cache

--- a/demo/HexMeshing/main.cc
+++ b/demo/HexMeshing/main.cc
@@ -6,6 +6,7 @@
  *  All contributors are stated in CREDITS.txt.                              *
 \*===========================================================================*/
 #include <CLI/CLI.hpp>
+#include <mpi.h>
 #include "HexMeshing.hh"
 
 #ifdef _WIN32
@@ -15,12 +16,13 @@
 #endif
 
 
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 
 #ifdef _WIN32
   SetErrorMode(0);
 #endif
+  MPI_Init(&argc, &argv);
 
   AlgoHex::Args args;
 


### PR DESCRIPTION
Depending on the solver libraries used and their configuration, we may need to call MPI_Init. Compare https://github.com/cgg-bern/AlgoHex/issues/3#issuecomment-1737671520