### PR TITLE
HexHex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ target_link_libraries(AlgoHex PUBLIC
         OpenVolumeMesh::OpenVolumeMesh
         CoMISo::CoMISo
         HexEx::HexEx
+        HexHex::HexHex
         Eigen3::Eigen
         GMM::GMM
         QGP3D::QGP3D

--- a/cmake/AlgoHexDependencies.cmake
+++ b/cmake/AlgoHexDependencies.cmake
@@ -38,6 +38,16 @@ if(NOT TARGET HexEx)
     FetchContent_MakeAvailable(hexex)
 endif()
 
+if(NOT TARGET HexHex)
+    FetchContent_Declare(hexhex
+        GIT_REPOSITORY https://github.com/cgg-bern/libHexHex.git
+        GIT_TAG main
+        SOURCE_DIR "${EXTERNAL_DIR}/libHexHex"
+        )
+    FetchContent_MakeAvailable(hexhex)
+    add_library(HexHex::HexHex ALIAS HexHex)
+endif()
+
 if(NOT TARGET Eigen3::Eigen)
     FetchContent_Declare(eigen
         URL https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.bz2

--- a/demo/HexMeshing/HexMeshing.cc
+++ b/demo/HexMeshing/HexMeshing.cc
@@ -23,12 +23,32 @@
 #include <AlgoHex/Stopwatches.hh>
 
 #include <HexHex/HexHex.hh>
+#include <HexHex/Utils/FileAccessor.hh>
 
 
 namespace AlgoHex
 {
 using Point = OpenVolumeMesh::Geometry::Vec3d;
 using TetMesh = OVM::TetrahedralGeometryKernel<Point, OVM::TetrahedralMeshTopologyKernel>;
+
+template<typename MeshT>
+static bool save_volume_mesh(const std::filesystem::path& _path, const MeshT& _mesh)
+{
+    const std::string ext = _path.extension();
+    if (ext == ".ovm") {
+        OpenVolumeMesh::IO::FileManager fm;
+        return fm.writeFile(_path, _mesh);
+    } else if (ext == ".ovmb") {
+        auto res = OpenVolumeMesh::IO::ovmb_write(_path, _mesh);
+        if (res != OVM::IO::WriteResult::Ok) {
+            std::cerr << OVM::IO::to_string(res) << std::endl;
+            return false;
+        }
+        return true;
+    }
+    std::cerr << "Unsupported file format: " << ext << std::endl;
+    return false;
+}
 
 void hexMeshing(Args &args)
 {
@@ -406,44 +426,77 @@ void extract_hexmesh(const Args &args, MeshT &tetmesh)
 {
   ScopedStopWatch sw(sw::hex_extraction);
 
-  std::cout << "\n#####Extracting hexmesh..." << std::endl;
-  auto parameters = tetmesh.template request_cell_property<std::map<OpenVolumeMesh::VertexHandle, TetMesh::PointT>>(
+  std::cout << "\n#####Extracting Hex Mesh..." << std::endl;
+
+  // Get the per cell parametrization
+  auto c_map_igm = tetmesh.template request_cell_property<std::map<OpenVolumeMesh::VertexHandle, TetMesh::PointT>>(
           "Parametrization");
-  HexEx::HexExtractor hexExtractor(tetmesh, parameters);
 
-  //save IGM
-  if (!args.igmOutFileName.empty())
-    hexExtractor.writeToFile(args.igmOutFileName);
-
-  hexExtractor.extract();
-  HexEx::HexahedralMesh hexmesh;
-  hexExtractor.getHexMesh(hexmesh, true);
-
-  std::cout << "Hexmesh cells: " << hexmesh.n_cells() << std::endl;
-  std::cout << "Hexmesh faces: " << hexmesh.n_faces() << std::endl;
-  std::cout << "Hexmesh edges: " << hexmesh.n_edges() << std::endl;
-  std::cout << "Hexmesh vertices: " << hexmesh.n_vertices() << std::endl;
-
-  auto hex_vol = hexmesh_volume(hexmesh);
-  auto tet_vol = tetmesh_volume(tetmesh);
-  std::cout << "#####Hexmesh volume / tetmesh voluem: " << hex_vol << "/" << tet_vol << " "
-                << hex_vol / tet_vol << std::endl;
-
-
-  //save hexmesh
-  if (!args.outFileName.empty())
-  {
-    OpenVolumeMesh::IO::FileManager fm;
-    fm.writeFile(args.outFileName, hexmesh);
+  // Convert per cell map to halfface prop used by HexHex
+  auto hf_igm = tetmesh.template request_halfface_property<OVM::Vec3d>("HexHex::Parametrization");
+  for (auto hf_it = tetmesh.hf_iter(); hf_it.is_valid(); ++hf_it) {
+      OVM::CH ch = tetmesh.incident_cell(*hf_it);
+      if (!ch.is_valid()) {continue;}
+      OVM::VH vh = tetmesh.halfface_opposite_vertex(*hf_it);
+      hf_igm[*hf_it] = c_map_igm[ch].at(vh);
   }
-  //save the boundary layer
-  if(!args.subHexOutFileName.empty())
+
+  // Setup HexHex Configuration
+  std::unique_ptr<HexHex::HexahedralMesh> hexmesh;
+  auto config = HexHex::Config();
+#ifdef _OPENMP
+  config.num_threads = omp_get_max_threads();
+#else
+  config.num_threads = 1;
+#endif
+  config.assert_igm_validity = true;
+  config.extract_piecewise_linear_faces = config.extract_piecewise_linear_edges = !args.piecewiseLinearOutFileName.empty();
+
+
+  // Save (unsanitized) IGM as .hexex
+  if (!args.igmOutFileName.empty()) {
+      HexHex::saveInputToHEXEX(args.igmOutFileName, tetmesh, hf_igm);
+  }
+
+  // Use HexHex to extract mesh
+  auto hexhex_res = HexHex::extractHexMesh(tetmesh, hf_igm, config);
+  if (hexhex_res.success) {
+      // HexHex was successful :D
+      hexmesh = std::move(hexhex_res.hex_mesh);
+  }
+  else
   {
-    OpenVolumeMesh::IO::FileManager fm;
-    HexEx::HexahedralMesh sub_mesh;
-    create_sub_hexmesh(hexmesh, sub_mesh);
-    auto sub_mesh_name = args.outFileName.substr(0, args.outFileName.size() - 7) + "sub_hex.ovm";
-    fm.writeFile(sub_mesh_name, sub_mesh);
+      // Use HexEx if HexHex fails :(
+      std::cerr << "Using HexEx for Mesh Extraction..." << std::endl;
+
+      HexEx::HexExtractor hexExtractor(tetmesh, c_map_igm);
+
+      hexExtractor.extract();
+      hexmesh = std::make_unique<HexEx::HexahedralMesh>();
+      hexExtractor.getHexMesh(*hexmesh, true);
+  }
+
+  // Print Mesh Volumes
+  // auto hex_vol = hexmesh_volume(*hexmesh);
+  // auto tet_vol = tetmesh_volume(tetmesh);
+  // std::cout << "#####Hexmesh volume / tetmesh volume: " << hex_vol << "/" << tet_vol << " "
+  //           << hex_vol / tet_vol << std::endl;
+
+  // Save Hex Mesh
+  if (!args.outFileName.empty()) {
+      save_volume_mesh(args.outFileName, *hexmesh);
+  }
+
+  // Save piecewise linear mesh if desired
+  if (hexhex_res.success && !args.piecewiseLinearOutFileName.empty()) {
+      save_volume_mesh(args.piecewiseLinearOutFileName, *hexhex_res.piecewise_linear_mesh);
+  }
+
+  // Save Boundary Layer Mesh
+  if(!args.subHexOutFileName.empty()) {
+      HexHex::HexahedralMesh boundary_mesh;
+      create_sub_hexmesh(*hexmesh, boundary_mesh);
+      save_volume_mesh(args.subHexOutFileName, boundary_mesh);
   }
 }
 

--- a/demo/HexMeshing/HexMeshing.cc
+++ b/demo/HexMeshing/HexMeshing.cc
@@ -22,6 +22,8 @@
 
 #include <AlgoHex/Stopwatches.hh>
 
+#include <HexHex/HexHex.hh>
+
 
 namespace AlgoHex
 {

--- a/demo/HexMeshing/main.cc
+++ b/demo/HexMeshing/main.cc
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 
   app.add_option("-i", args.inFileName, "Input tetrahedral mesh in .ovm/.vtk format (optional).");
   app.add_option("-o", args.outFileName,
-                 "Output hexhedral mesh in .ovm format (optional, default: *_inFileName +'_hex'+'.ovm').");
+                 "Output hexhedral mesh in .ovm(b) format (optional, default: *_inFileName +'_hex'+'.ovm').");
   app.add_option("--vertex-quaternion-out-path", args.vertexQtOutFileName,
                  "Save vertex quaternions in .qtn format (optional).");
   app.add_option("--refined-mesh-in-path", args.rfInFileName, "Load refined mesh in .ovm format (optional).");
@@ -136,7 +136,9 @@ int main(int argc, char *argv[])
   app.add_option("--animation-out-path", args.animationOutFileName,
                  "Save the singularity graph development during the locally meshable field generation in .ovm format (optional).");
   app.add_option("--sub-hexmesh-out-path", args.subHexOutFileName,
-                 "Save the boundary layer of the output hex mesh in .ovm format (optional).");
+                 "Save the boundary layer of the output hex mesh in .ovm(b) format (optional).");
+  app.add_option("--piecewiselinear-out-path", args.piecewiseLinearOutFileName,
+                 "Save the piecewise linear mesh in .ovm(b) format (optional).");
 
   try
   {

--- a/src/AlgoHex/Args.hh
+++ b/src/AlgoHex/Args.hh
@@ -6,6 +6,7 @@
  *  All contributors are stated in CREDITS.txt.                              *
 \*===========================================================================*/
 #pragma once
+#include <string>
 
 namespace AlgoHex
 {
@@ -193,6 +194,9 @@ struct Args
 
   // Save the boundary layer of the output hex mesh
   std::string subHexOutFileName;
+
+  // Save the piecewise linear mesh
+  std::string piecewiseLinearOutFileName;
 };
 
 //=============================================================================


### PR DESCRIPTION
Integrate HexHex into the AlgoHex HexMeshing Demo Pipeline.
- Once the IGM is generated, HexHex attempts to extract a mesh. If it fails (i.e. the IGM is not valid), HexEx is used instead.
- Add the optional parameter --piecewiselinear-out-path to store the piecewise linear mesh (extracted by HexHex only) in ovm or ovmb format.